### PR TITLE
Add parameter to OnMaintenance function

### DIFF
--- a/lua/entities/lvs_base_starfighter/init.lua
+++ b/lua/entities/lvs_base_starfighter/init.lua
@@ -194,7 +194,7 @@ function ENT:PhysicsSimulate( phys, deltatime )
 	return ForceAngle, ForceLinear, SIM_LOCAL_ACCELERATION
 end
 
-function ENT:OnMaintenance()
+function ENT:OnMaintenance(entity)
 	for _, Engine in pairs( self:GetEngines() ) do
 		if not IsValid( Engine ) then continue end
 

--- a/lua/entities/lvs_walker_atte/init.lua
+++ b/lua/entities/lvs_walker_atte/init.lua
@@ -168,7 +168,7 @@ function ENT:OnTick()
 	self:ContraptionThink()
 end
 
-function ENT:OnMaintenance()
+function ENT:OnMaintenance(entity)
 	self:UnRagdoll()
 end
 

--- a/lua/entities/lvs_walker_hsd/init.lua
+++ b/lua/entities/lvs_walker_hsd/init.lua
@@ -140,7 +140,7 @@ function ENT:OnTick()
 	self:ContraptionThink()
 end
 
-function ENT:OnMaintenance()
+function ENT:OnMaintenance(entity)
 	self:UnRagdoll()
 end
 


### PR DESCRIPTION
Updated the OnMaintenance function in lvs_base_starfighter, lvs_walker_atte, and lvs_walker_hsd entities to include an 'entity' parameter. This change likely improves functionality or prepares for future enhancements involving the passed entity.